### PR TITLE
Add GH actions

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,21 @@
+GitHub Actions: Release secrets & setup
+
+This file lists the GitHub secrets and minimal setup required to use the workflows in `.github/workflows/`.
+
+Android (Google Play)
+- Required secret: `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+  - Value: the JSON contents of a Google Play service account (create a service account in Google Play Console and grant `Release` permissions). Store the JSON as a secret.
+  - The workflow publishes to the `internal` track by default. Change `.github/workflows/android-deploy.yml` to modify `track` or package name.
+- Ensure `packageName` in the workflow matches the app id in `move/android/app/src/main/AndroidManifest.xml` (default: `com.protocentral.healthypi_move`).
+
+iOS (App Store)
+- Required secrets:
+  - `APP_STORE_CONNECT_API_KEY` — the JSON content of the App Store Connect API key (the key downloaded from Apple; the workflow writes this to a file at runtime).
+  - `APP_SPECIFIC_PASSWORD` — an app-specific password for uploading builds (or configure Fastlane App Store Connect auth via environment variables or credentials manager).
+  - Optionally: `FASTLANE_SESSION` or other Fastlane-specific secrets if you use fastlane match or other flows.
+- The workflow assumes a `fastlane` configuration exists under `move/ios/fastlane` and there's a `release` lane that uploads to App Store Connect. If not present, initialize Fastlane in `move/ios` and add a `release` lane.
+
+Notes & limitations
+- These workflows run in CI and will only succeed if the repository has correct signing credentials (Android keystore and iOS signing certs/profiles). For Android, use `android/key.properties` and store sensitive keystore contents in a secure place (or use GitHub Secrets + Fastlane match). For iOS, set up code signing with Fastlane match or provide provisioning profiles and certificates via secrets.
+- CI cannot interactively unlock macOS Keychain; for production iOS builds use Fastlane match and App Store Connect API keys for non-interactive uploads.
+- This repository's Flutter code is in `move/` — all build commands run from there.

--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -1,0 +1,86 @@
+name: Android Build & Deploy
+
+on:
+  push:
+    branches: [ main, 'release/**' ]
+    tags: ['*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build AAB and APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 'stable'
+
+      - name: Cache pub
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            move/.dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('move/pubspec.yaml') }}
+
+      - name: Install dependencies
+        run: |
+          cd move
+          flutter pub get
+          flutter pub upgrade
+
+      - name: Run analyzer
+        run: |
+          cd move
+          flutter analyze || true
+
+      - name: Build AAB (release)
+        run: |
+          cd move
+          flutter build appbundle --release --no-shrink
+
+      - name: Build APK (release)
+        run: |
+          cd move
+          flutter build apk --release --no-shrink
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-builds
+          path: |
+            move/build/app/outputs/bundle/release/*.aab
+            move/build/app/outputs/flutter-apk/app-release.apk
+
+  publish:
+    name: Publish to Google Play (Internal)
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: android-builds
+
+      - name: Publish to Google Play
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: 'com.protocentral.healthypi_move'
+          releaseFiles: |
+            move/build/app/outputs/bundle/release/*.aab
+          track: internal

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -1,0 +1,56 @@
+name: iOS Build & Deploy
+
+on:
+  push:
+    branches: [ main, 'release/**' ]
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby (for fastlane)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install CocoaPods
+        run: |
+          sudo gem install cocoapods -v 1.12.0 || true
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 'stable'
+
+      - name: Install dependencies
+        run: |
+          cd move
+          flutter pub get
+          cd ios
+          pod install --repo-update
+
+      - name: Build iOS (ipa)
+        env:
+          LANG: en_US.UTF-8
+        run: |
+          cd move
+          flutter build ipa --release --export-method app-store
+
+      - name: Setup Fastlane credentials
+        run: |
+          mkdir -p ~/fastlane
+          echo "${{ secrets.APP_STORE_CONNECT_API_KEY }}" > ~/fastlane/app_store_connect_api_key.json
+
+      - name: Upload to App Store via Fastlane
+        working-directory: move/ios
+        run: |
+          # ensure bundler deps (if present)
+          bundle install || true
+          # run fastlane with the app-specific password and API key path
+          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="${{ secrets.APP_SPECIFIC_PASSWORD }}" \
+          APP_STORE_CONNECT_API_KEY_PATH=~/fastlane/app_store_connect_api_key.json \
+          bundle exec fastlane ios release

--- a/move/ios/Podfile.lock
+++ b/move/ios/Podfile.lock
@@ -67,6 +67,9 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
   - SwiftCBOR (0.4.7)
   - SwiftProtobuf (1.31.1)
   - SwiftyGif (5.4.5)
@@ -87,6 +90,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -125,30 +129,33 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_archive: cb3e0219e555897ba4b36f166baa1eca394890b9
-  flutter_blue_plus_darwin: 904ed52825285a15f60e9d90312337a09f11a785
-  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  flutter_archive: ad8edfd7f7d1bb12058d05424ba93e27d9930efe
+  flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   iOSMcuManagerLibrary: e9555825af11a61744fe369c12e1e66621061b58
-  mcumgr_flutter: 0be6d7dcb0e57214bf4acfba8acbe045f18af83d
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  mcumgr_flutter: 969e99cc15e9fe658242669ce1075bf4612aef8a
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   SDWebImage: 9f177d83116802728e122410fb25ad88f5c7608a
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftCBOR: 465775bed0e8bac7bfb8160bcf7b95d7f75971e4
   SwiftProtobuf: e02f51c8c2df5845657aee2d4de9d61bf50ef788
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce


### PR DESCRIPTION
This pull request introduces automated CI/CD workflows for building and releasing the Android and iOS apps using GitHub Actions. It also documents the required secrets and setup for secure publishing to Google Play and the App Store. The main changes are the addition of build and deployment workflows for both platforms and a comprehensive guide for configuring secrets.

**CI/CD Workflow Additions:**

* Added `.github/workflows/android-deploy.yml` to automate building APK/AAB artifacts and publishing Android releases to Google Play (internal track) upon tag push, using GitHub Actions and required secrets for authentication.
* Added `.github/workflows/ios-deploy.yml` to automate building the iOS app and uploading to App Store Connect via Fastlane, with proper handling of dependencies and secrets.

**Documentation and Setup:**

* Added `.github/RELEASE.md` to document all required GitHub secrets, minimal setup, and limitations for using the Android and iOS deployment workflows, including instructions for configuring signing credentials and Fastlane.