### PR TITLE
Gate native HRV record download behind a flag until firmware emits them

### DIFF
--- a/lib/feature_flags.dart
+++ b/lib/feature_flags.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2024-2026 ProtoCentral
+// SPDX-License-Identifier: MIT
+
+/// Build-time feature gates for work that is complete on the app side but
+/// waiting on something outside it.
+///
+/// Flags here are `const`, so a disabled feature is tree-shaken out of release
+/// builds rather than merely hidden. Keep them few and short-lived: a flag that
+/// outlives its reason becomes a second, undocumented product.
+library;
+
+/// Native **HRV R-R interval records** (HPI_HS `RECORDS` signal `0x05`).
+///
+/// Off because **the firmware does not emit these yet**. The app side is
+/// finished and tested — listing, download, CRC, the uint16-ms decode, the
+/// tachogram, the per-beat CSV, and the interval-series handling that stops an
+/// R-R record being mistaken for a fixed-rate waveform. None of it can be
+/// exercised until a watch produces signal `0x05`, and shipping a filter chip
+/// that is permanently empty invites a bug report rather than a feature.
+///
+/// **This does not gate ECG-derived HRV.** The spot-check that detects R peaks
+/// in an ECG recording and reports RMSSD/SDNN/pNN50 runs on records the firmware
+/// already produces, is live, and is the half of the feature that works today.
+/// It is also the reference the native path will eventually be validated
+/// against, so it must stay reachable.
+///
+/// To re-enable when firmware lands: flip this to `true`, then confirm against a
+/// real recording that the header's `sampleFormat` is `2` (uint16) and that
+/// `nSamples` counts intervals rather than bytes — the decode and every duration
+/// shown in the UI depend on both. See `HsRecording.isIntervalSeries`.
+const bool kHrvRecordsEnabled = false;

--- a/lib/screens/scr_recording_preview.dart
+++ b/lib/screens/scr_recording_preview.dart
@@ -9,6 +9,7 @@ import 'package:healthypi_healthy_store/healthypi_healthy_store.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../feature_flags.dart';
 import '../models/hs_recording.dart';
 import '../theme/hpi_colors.dart';
 import '../theme/hpi_text.dart';
@@ -67,6 +68,11 @@ class _ScrRecordingPreviewState extends State<ScrRecordingPreview> {
     final channel = _samples.data.first;
 
     if (r.kind == HsRecordingKind.hrv) {
+      // Gated: firmware emits no signal 0x05 yet, so this path is unreachable
+      // in practice and untested against a real record. The ECG branch below is
+      // deliberately *not* gated — it runs on records the watch already
+      // produces and is the reference this path will be validated against.
+      if (!kHrvRecordsEnabled) return;
       // Already intervals in milliseconds — no detection to do.
       final series = RrSeries.filtered(channel);
       _rr = series;

--- a/lib/screens/scr_recordings.dart
+++ b/lib/screens/scr_recordings.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../feature_flags.dart';
 import '../models/hs_recording.dart';
 import '../theme/hpi_colors.dart';
 import '../theme/hpi_text.dart';
@@ -26,9 +27,31 @@ class ScrRecordings extends StatefulWidget {
   State<ScrRecordings> createState() => _ScrRecordingsState();
 }
 
-/// Order must match the segmented control's labels — the control reports an
-/// index straight into [_Filter.values].
-enum _Filter { all, ecg, hrv, ppg, gsr, imu }
+/// A library filter chip.
+///
+/// Each case carries its own [label], and the control is built from
+/// [_visibleFilters] rather than from `_Filter.values` with a parallel list of
+/// strings. That coupling ("order must match the labels") could not survive a
+/// conditionally-hidden chip: hiding one shifts every later index, so the
+/// segmented control would report GSR and select IMU.
+enum _Filter {
+  all('All'),
+  ecg('ECG'),
+  hrv('HRV'),
+  ppg('PPG'),
+  gsr('GSR'),
+  imu('IMU');
+
+  const _Filter(this.label);
+  final String label;
+
+  /// Chips actually shown. HRV is hidden while [kHrvRecordsEnabled] is off —
+  /// the firmware emits no such records, so the chip would always be empty.
+  static List<_Filter> get visible => [
+        for (final f in _Filter.values)
+          if (f != _Filter.hrv || kHrvRecordsEnabled) f,
+      ];
+}
 
 class _ScrRecordingsState extends State<ScrRecordings> {
   List<HsRecording>? _sessions;
@@ -249,7 +272,15 @@ class _ScrRecordingsState extends State<ScrRecordings> {
   @override
   Widget build(BuildContext context) {
     final all = _sessions;
-    final shown = all?.where(_matches).toList() ?? const <HsRecording>[];
+    // Also drop HRV rows outright while the feature is gated. The chip is
+    // hidden, but a bench build could still emit signal 0x05 — and a row that
+    // downloads into a preview whose HRV analysis is switched off is a worse
+    // outcome than not listing it.
+    final shown = all
+            ?.where(_matches)
+            .where((s) => kHrvRecordsEnabled || s.kind != HsRecordingKind.hrv)
+            .toList() ??
+        const <HsRecording>[];
 
     return Scaffold(
       backgroundColor: HpiColors.background,
@@ -267,9 +298,10 @@ class _ScrRecordingsState extends State<ScrRecordings> {
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 28),
           children: [
             HpiSegmentedControl(
-              segments: const ['All', 'ECG', 'HRV', 'PPG', 'GSR', 'IMU'],
-              selectedIndex: _filter.index,
-              onChanged: (i) => setState(() => _filter = _Filter.values[i]),
+              segments: [for (final f in _Filter.visible) f.label],
+              selectedIndex: _Filter.visible.indexOf(_filter).clamp(0, 99),
+              onChanged: (i) =>
+                  setState(() => _filter = _Filter.visible[i]),
             ),
             const SizedBox(height: 16),
             if (_busy && all == null)
@@ -382,8 +414,9 @@ class _ScrRecordingsState extends State<ScrRecordings> {
           Text('No recordings', style: HpiText.appBarTitle),
           const SizedBox(height: 6),
           Text(
-              'ECG, HRV, PPG, GSR and IMU sessions are all started on the '
-              'watch, then downloaded here on demand.',
+              '${kHrvRecordsEnabled ? "ECG, HRV, PPG" : "ECG, PPG"}, GSR and '
+              'IMU sessions are all started on the watch, then downloaded here '
+              'on demand.',
               textAlign: TextAlign.center,
               style: HpiText.body.copyWith(fontSize: 12)),
         ],


### PR DESCRIPTION
The app side of HRV R-R records is finished and tested, but no firmware produces signal 0x05 yet, so every part of it is unreachable in practice and unvalidated against a real record. A filter chip that is permanently empty reads as a broken feature, not a pending one.

`kHrvRecordsEnabled` in lib/feature_flags.dart turns it off in four places: the HRV chip is dropped from the library filter, HRV rows are filtered out of the list even if a bench build emits them, the empty-state copy stops promising them, and the preview's native R-R branch returns early. Being `const`, the disabled paths are tree-shaken from release builds rather than merely hidden.

**ECG-derived HRV is deliberately not gated.** The spot check that finds R peaks in an ECG recording and reports RMSSD/SDNN/pNN50 runs on records the watch already produces, works today, and is the reference the native path will be validated against when it lands — gating it would remove the more useful half of the feature and the means of checking the other half.

Hiding a chip forced a real fix rather than a conditional: the filter enum's "order must match the labels" contract could not survive it, because omitting one entry shifts every later index and the control would report GSR while selecting IMU. Each case now carries its own label and the control is built from the visible list, so the parallel-array coupling is gone for good.

Nothing is deleted. The decode, tachogram, per-beat CSV and interval-series handling all stay, with the re-enable steps recorded on the flag: flip it, then confirm against a real recording that sampleFormat is 2 and that nSamples counts intervals rather than bytes.

Verified: 0 analyzer errors, 162 tests pass (the one failure is the pre-existing sqflite harness gap), build bundle clean.